### PR TITLE
Move src property out

### DIFF
--- a/src/lib/analyses/cfg/dominate.dl
+++ b/src/lib/analyses/cfg/dominate.dl
@@ -29,38 +29,38 @@ dominate(pred, succ) :-
 
 /// Assignment
 dominate(pred, succ) :-
-    Assignment(_, _, _, _, succ, pred).
+    Assignment(_, _, _, succ, pred).
 
 /// BinaryOperation
 dominate(pred, succ) :-
-    BinaryOperation(boId, _, _, _, pred, succ, _, _).
+    BinaryOperation(boId, _, _, pred, succ, _, _).
 
 /// Conditional
 dominate(pred, succ) :-
-    Conditional(_, _, _, pred, succ, _).
+    Conditional(_, _, pred, succ, _).
 
 dominate(pred, succ) :-
-    Conditional(_, _, _, pred, _, succ).
+    Conditional(_, _, pred, _, succ).
 
 /// FunctionCall
 dominate(pred, succ) :-
-    FunctionCall(fcId, _, _, _, _),
+    FunctionCall(fcId, _, _, _),
     FunctionCall_vArguments(fcId, pred, i),
     FunctionCall_vArguments(fcId, succ, i + 1).
 
 /// IndexAccess
 dominate(pred, succ) :-
-    IndexAccess(_, _, _, succ, pred, 1).
+    IndexAccess(_, _, succ, pred, 1).
 
 /// IndexRangeAccess
 dominate(pred, succ) :-
-    IndexRangeAccess(_, _, _, succ, pred, 1, _, _).
+    IndexRangeAccess(_, _, succ, pred, 1, _, _).
 
 dominate(pred, succ) :-
-    IndexRangeAccess(_, _, _, succ, _, _, pred, 1).
+    IndexRangeAccess(_, _, succ, _, _, pred, 1).
 
 /// TupleExpression
 dominate(pred, succ) :-
-    TupleExpression(tId, _, _, _),
+    TupleExpression(tId, _, _),
     TupleExpression_components(tId, pred, i),
     TupleExpression_components(tId, succ, i + 1).

--- a/src/lib/analyses/cfg/dominateStmt.dl
+++ b/src/lib/analyses/cfg/dominateStmt.dl
@@ -4,69 +4,69 @@
 // ForStatement
 // Initialization stmt comes before body
 dominateStmt(pred, succ) :-
-    ForStatement(_, _, succ, pred, 1, _, _, _, _).
+    ForStatement(_, succ, pred, 1, _, _, _, _).
 
 // All stmts dominating the for dominate the init statement
 dominateStmt(pred, succ) :-
-    ForStatement(fId, _, _, succ, 1, _, _, _, _),
+    ForStatement(fId, _, succ, 1, _, _, _, _),
     dominateStmt(pred, fId).
 
 // No init statement - all stmts dominating the for dominate the body
 dominateStmt(pred, succ) :-
-    ForStatement(fId, _, succ, _, 0, _, _, _, _),
+    ForStatement(fId, succ, _, 0, _, _, _, _),
     dominateStmt(pred, fId).
 
 // TryStatement
 dominateStmt(pred, succ) :-
-    TryStatement(tId, _, _),
+    TryStatement(tId, _),
     dominateStmt(pred, tId),
     TryStatement_vClauses(tId, cId, _),
-    TryCatchClause(cId, _, _, succ, _, _).
+    TryCatchClause(cId, _, succ, _, _).
 
 // BlockStatement
 dominateStmt(pred, succ) :-
-    Block(bId, _),
+    Block(bId),
     dominateStmt(pred, bId),
     Block_vStatements(bId, succ, 0).
 
 dominateStmt(pred, succ) :-
-    Block(bId, _),
+    Block(bId),
     Block_vStatements(bId, pred, i),
     Block_vStatements(bId, succ, i + 1).
 
 // UncheckedBlockStatement
 dominateStmt(pred, succ) :-
-    UncheckedBlock(bId, _),
+    UncheckedBlock(bId),
     dominateStmt(pred, bId),
     UncheckedBlock_vStatements(bId, succ, 0).
 
 dominateStmt(pred, succ) :-
-    UncheckedBlock(bId, _),
+    UncheckedBlock(bId),
     UncheckedBlock_vStatements(bId, pred, i),
     UncheckedBlock_vStatements(bId, succ, i + 1).
 
 // WhileStatement
 dominateStmt(pred, succ) :-
-    WhileStatement(wId, _, _, succ),
+    WhileStatement(wId, _, succ),
     dominateStmt(pred, wId).
 
 // IfStatement
 dominateStmt(pred, succ) :-
-    IfStatement(ifId, _, _, succ, _, _),
+    IfStatement(ifId, _, succ, _, _),
     dominateStmt(pred, ifId).
 
 dominateStmt(pred, succ) :-
-    IfStatement(ifId, _, _, _, succ, 1),
+    IfStatement(ifId, _, _, succ, 1),
     dominateStmt(pred, ifId).
 
 // DoWhile statement
 dominateStmt(pred, succ) :-
-    DoWhileStatement(dwId, _, _, succ),
+    DoWhileStatement(dwId, _, succ),
     dominateStmt(pred, dwId).
 
 // ModifierInvocations
 dominateStmt(pred, succ) :-
-    FunctionDefinition(id, _, _, _, _, _, _, _, _, _, _, _, _, _, _),
+    FunctionDefinition(id, _, _, _, _, _, _, _, _, _, _, _, _, _),
     FunctionDefinition_vModifiers(id, pred, i),
     modifierInvocation_isModifier(pred),
     FunctionDefinition_vModifiers(id, succ, i + 1),
@@ -74,7 +74,7 @@ dominateStmt(pred, succ) :-
 
 // ModifierInvocations
 dominateStmt(pred, succ) :-
-    FunctionDefinition(id, _, _, _, _, _, _, _, _, _, _, _, _, succ, 1),
+    FunctionDefinition(id, _, _, _, _, _, _, _, _, _, _, _, succ, 1),
     FunctionDefinition_vModifiers(id, pred, i),
     modifierInvocation_isModifier(pred).
 

--- a/src/lib/analyses/common.dl
+++ b/src/lib/analyses/common.dl
@@ -6,26 +6,26 @@ ancestor(x, y) :- parent(x, z), ancestor(z, y).
 
 // Helper to get the name of a state var with a given id
 .decl stateVar(name: symbol, id: id)
-stateVar(name, id) :- VariableDeclaration(id, _, _, _, name, _, 1, _, _, _, _, _, _, _, _, _, _).
+stateVar(name, id) :- VariableDeclaration(id, _, _, name, _, 1, _, _, _, _, _, _, _, _, _, _).
 
 // Helper to get the name of a function with a given id
 .decl function(name: symbol, id: id)
-function(name, id) :- FunctionDefinition(id, _, _, _, name, _, _, _, _, _, _, _, _, _, _).
+function(name, id) :- FunctionDefinition(id, _, _, name, _, _, _, _, _, _, _, _, _, _).
 
 // Helper to get the name of a function with a given id in a given contract (contractId)
 .decl functionIn(name: symbol, id: FunctionDefinitionId, contractId: id)
-functionIn(name, id, contractId) :- FunctionDefinition(id, _, contractId, _, name, _, _, _, _, _, _, _, _, _, _).
+functionIn(name, id, contractId) :- FunctionDefinition(id, contractId, _, name, _, _, _, _, _, _, _, _, _, _).
 
 // Helper to get the name of a contract with a given id
 .decl contract(name: symbol, id: id)
-contract(name, id) :- ContractDefinition(id, _, name, _, _, _, _).
+contract(name, id) :- ContractDefinition(id, name, _, _, _, _).
 
 /// Specifies that a childContractId inherits from baseContractId (or is the same contract)
 .decl inherits(childContractId: ContractDefinitionId, baseContractId: ContractDefinitionId)
-inherits(childContractId, baseContractId) :- ContractDefinition(childContractId, _, _, _, _, _, _), childContractId = baseContractId.
+inherits(childContractId, baseContractId) :- ContractDefinition(childContractId, _, _, _, _, _), childContractId = baseContractId.
 inherits(childContractId, baseContractId) :-
-    ContractDefinition(childContractId, _, _, _, _, _, _),
-    ContractDefinition(baseContractId, _, _, _, _, _, _),
+    ContractDefinition(childContractId, _, _, _, _, _),
+    ContractDefinition(baseContractId, _, _, _, _, _),
     ContractDefinition_linearizedBaseContracts(childContractId, baseContractId, _).
 
 /// Specifies that a method with `methodId` belongs to contract `contractId` or one of its bases.
@@ -34,11 +34,11 @@ method(contractId, methodId) :- inherits(contractId, baseId), functionIn(_ ,meth
 
 .decl ModifierInvocation_vReferencedDeclaration(mId: id, rId: id)
 ModifierInvocation_vReferencedDeclaration(mId, rId) :-
-    ModifierInvocation(mId, _, mNameId, _, _),
-    (Identifier(mNameId, _, _, _, rId); IdentifierPath(mNameId, _, _, rId)).
+    ModifierInvocation(mId, mNameId, _, _),
+    (Identifier(mNameId, _, _, rId); IdentifierPath(mNameId, _, rId)).
 
 .decl modifierInvocation_isModifier(mid: id)
 modifierInvocation_isModifier(mId) :-
-    ModifierInvocation(mId, _, _, _, _),
+    ModifierInvocation(mId, _, _, _),
     ModifierInvocation_vReferencedDeclaration(mId, rId),
-    ModifierDefinition(rId, _, _, _, _, _, _, _, _, _).
+    ModifierDefinition(rId, _, _, _, _, _, _, _, _).

--- a/src/lib/analyses/state_var_modified.dl
+++ b/src/lib/analyses/state_var_modified.dl
@@ -3,19 +3,19 @@
 
 // Simple reference to the variable
 stateVarModifiedInLHS(varId, exprId) :-
-    Identifier(exprId, _, _, _, varId).
+    Identifier(exprId, _, _, varId).
 // A member access referring to the variable (e.g. this.x, Foo.x)
 stateVarModifiedInLHS(varId, exprId) :-
-    MemberAccess(exprId, _, _, _, _, varId).
+    MemberAccess(exprId, _, _, _, varId).
 // A struct member access x.foo
 stateVarModifiedInLHS(varId, exprId) :-
-    MemberAccess(exprId, _, _, subExprId, _, _), stateVarModifiedInLHS(varId, subExprId). // A str
+    MemberAccess(exprId, _, subExprId, _, _), stateVarModifiedInLHS(varId, subExprId). // A str
 // An index into the state var x[a]
 stateVarModifiedInLHS(varId, exprId) :-
-    IndexAccess(exprId, _, _, baseExprId, _, _), stateVarModifiedInLHS(varId, baseExprId).
+    IndexAccess(exprId, _, baseExprId, _, _), stateVarModifiedInLHS(varId, baseExprId).
 // An tuple expression
 stateVarModifiedInLHS(varId, exprId) :-
-    TupleExpression(exprId, _, _, 0), 
+    TupleExpression(exprId, _, 0), 
     TupleExpression_components(exprId, componentId, _),
     componentId >= 0,
     stateVarModifiedInLHS(varId, componentId).
@@ -25,7 +25,7 @@ stateVarModifiedInLHS(varId, exprId) :-
 
 // Simple assignment case
 varModifiedInLHSOfAssignment(varId, assignmentId) :-
-    Assignment(assignmentId, _, _, _, lhsId, _),
+    Assignment(assignmentId, _, _, lhsId, _),
     stateVarModifiedInLHS(varId, lhsId).
 
 // Compute whether the state var "varContractName.stateVarName" is changed  inside the method "funContractName.funName"
@@ -38,6 +38,6 @@ stateVarAssignedIn(varContractName, stateVarName, funContractName, funName) :-
     ancestor(varContractId, sId),
     function(funName, fId),
     ancestor(funContractId, fId),
-    Assignment(assignId, _, _, _, _, _),
+    Assignment(assignId, _, _, _, _),
     ancestor(fId, assignId),
     varModifiedInLHSOfAssignment(sId, assignId).

--- a/src/lib/detectors/msg_sender_inconsistency.dl
+++ b/src/lib/detectors/msg_sender_inconsistency.dl
@@ -6,14 +6,14 @@
 // Computes all function with id funId that have `msg.sender` expression with id eId
 .decl funHasMsgSenderBuiltin(funId: id, eId: id)
 funHasMsgSenderBuiltin(funId, eId) :-
-    MemberAccess(eId, _, _, baseId, "sender", _),
-    Identifier(baseId, _, _, "msg", _),
+    MemberAccess(eId, _, baseId, "sender", _),
+    Identifier(baseId, _, "msg", _),
     ancestor(funId, eId).
 
 // Computes all function with id funId that have `_msgSender` expression with id eId
 .decl funHasMsgSenderCall(funId: id, eId: id)
 funHasMsgSenderCall(funId, eId) :-
-    Identifier(eId, _, _, "_msgSender", _),
+    Identifier(eId, _, "_msgSender", _),
     ancestor(funId, eId).
 
 /// MAIN DETECTOR RELATION

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -61,10 +61,7 @@ describe("Integration test on samples", () => {
 
                 for (const unit of units) {
                     unit.walk((node) => {
-                        const rx = new RegExp(
-                            `${node.type}\\(${node.id}, "${node.src}".*\\)`,
-                            "gm"
-                        );
+                        const rx = new RegExp(`${node.type}\\(${node.id}.*\\)`, "gm");
 
                         if (!rx.test(datalog)) {
                             missing.add(node);
@@ -73,6 +70,22 @@ describe("Integration test on samples", () => {
                 }
 
                 sol.assert(missing.size === 0, `Missing nodes {0}`, missing);
+            });
+
+            it("each AST node has a src fact", () => {
+                const missing = new Set<sol.ASTNode>();
+
+                for (const unit of units) {
+                    unit.walk((node) => {
+                        const rx = new RegExp(`src\\(${node.id}, "${node.src}"\\)`, "gm");
+
+                        if (!rx.test(datalog)) {
+                            missing.add(node);
+                        }
+                    });
+                }
+
+                sol.assert(missing.size === 0, `Missing srcs for nodes {0}`, missing);
             });
 
             it("souffle is able to process the output", () => {


### PR DESCRIPTION
Moved the src property from outside node declarations into a separate relation. So now instead of:

```
.decl VariableDeclaration(id: id, src: symbol, ...)
```

We have:

```
.decl VariableDeclaration(id: id, ...)
```

And when emitting facts we will emit:

```
VariableDeclaration(10, ...).
src(10, "4:5:6").
```