### PR TITLE
Add new SouffleCSVToSQLInstance and related tests

### DIFF
--- a/test/analyses.spec.ts
+++ b/test/analyses.spec.ts
@@ -104,7 +104,7 @@ describe("Analyses work in sqlite mode", () => {
             )) as SouffleSQLiteInstance;
 
             for (const [key, val] of Object.entries(expectedOutput)) {
-                const actualResutls = (await instance.getRelation(key)).map((f) => f.fields);
+                const actualResutls = (await instance.relationFacts(key)).map((f) => f.fields);
                 expect(actualResutls).toEqual(val);
             }
 

--- a/test/instances.spec.ts
+++ b/test/instances.spec.ts
@@ -1,0 +1,69 @@
+import expect from "expect";
+import * as sol from "solc-typed-ast";
+import { buildDatalog } from "../src";
+import {
+    SouffleCSVInstance,
+    SouffleCSVToSQLInstance,
+    SouffleInstanceI
+} from "../src/lib/souffle/instance";
+import { join } from "path";
+
+const MY_DIR = __dirname;
+const DIST_SO_DIR = join(MY_DIR, "../dist/functors");
+
+describe("Instances have equivalent behavior", () => {
+    const samples: Array<[string, string[]]> = [["test/samples/analyses/fcall.sol", ["callsPath"]]];
+    // The SouffleSQLiteInstance doesnt work on record types due to
+    const instances = [SouffleCSVInstance /*SouffleSQLiteInstance,*/, SouffleCSVToSQLInstance];
+
+    for (const [sample, analyses] of samples) {
+        describe(sample, () => {
+            let units: sol.SourceUnit[];
+            let datalog: string;
+            let reader: sol.ASTReader;
+            let version: string;
+            let firstInstance: SouffleInstanceI;
+
+            before(async () => {
+                reader = new sol.ASTReader();
+                const result = await sol.compileSol(sample, "auto");
+
+                const data = result.data;
+                const errors = sol.detectCompileErrors(data);
+
+                expect(errors).toHaveLength(0);
+                version = result.compilerVersion as string;
+
+                units = reader.read(data);
+
+                expect(units.length).toBeGreaterThanOrEqual(1);
+
+                const infer = new sol.InferType(version);
+                datalog = buildDatalog(units, infer);
+
+                firstInstance = new instances[0](datalog, DIST_SO_DIR);
+                await firstInstance.run(analyses);
+            });
+
+            for (let i = 1; i < instances.length; i++) {
+                it(`Instance ${instances[0].name} and ${instances[i].name} produce the same results`, async () => {
+                    const otherInstance = new instances[i](datalog, DIST_SO_DIR);
+
+                    await otherInstance.run(analyses);
+
+                    for (const analysis of analyses) {
+                        const firstInstResult = (await firstInstance.relationFacts(analysis)).map(
+                            (fact) => fact.toJSON()
+                        );
+                        const otherInstResult = (await otherInstance.relationFacts(analysis)).map(
+                            (fact) => fact.toJSON()
+                        );
+
+                        expect(firstInstResult.length > 0).toBeTruthy();
+                        expect(firstInstResult).toEqual(otherInstResult);
+                    }
+                });
+            }
+        });
+    }
+});


### PR DESCRIPTION
Due to https://github.com/souffle-lang/souffle/issues/2457 the `SouffleSQLInstance` cannot return record types. We need those for some analyses. To work around this issue we added a new `SouffleCSVToSQLInstance` that:

1. Dumps results to CSV
2. Reads the CSV files and puts them into an SQLite db
3. Exposes the same interface as the `SouffleSQLinstance`

There is a related test that checks all instances produce the same results for some analysis

Note that the different instance interfaces, and some of the helper functions for Facts seem suspiciously similar. We amy want to do a pass later on to reduce code duplication.