### PR TITLE
Fix bugs in csv-to-sql instance

### DIFF
--- a/src/lib/souffle/fact.ts
+++ b/src/lib/souffle/fact.ts
@@ -102,8 +102,7 @@ function parseFieldValFromCsv(val: any, typ: DatalogType): FieldVal {
     }
 
     if (typ === DatalogSymbol) {
-        sol.assert(typeof val === "string", `Expected a string`);
-        return val;
+        return String(val);
     }
 
     if (typ instanceof DatalogSubtype) {
@@ -173,7 +172,6 @@ export class Fact {
 
     static fromCSVRows(rel: Relation, rows: string[][]): Fact[] {
         const fieldTypes = rel.fields.map(([, typ]) => typ);
-        sol.assert(rows[0].length === fieldTypes.length, ``);
 
         return rows.map(
             (cols) =>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -21,6 +21,26 @@ export function zip<T1, T2>(x: T1[], y: T2[]): Array<[T1, T2]> {
     return res;
 }
 
+export function chunk<T>(arr: T[], chunkSize: number): T[][] {
+    const res: T[][] = [];
+    let chunk: T[] = [];
+
+    for (const x of arr) {
+        if (chunk.length === chunkSize) {
+            res.push(chunk);
+            chunk = [];
+        }
+
+        chunk.push(x);
+    }
+
+    if (chunk.length > 0) {
+        res.push(chunk);
+    }
+
+    return res;
+}
+
 /**
  * Convert a TS list into a datalog "recursive" list.
  */

--- a/test/instances.spec.ts
+++ b/test/instances.spec.ts
@@ -12,17 +12,18 @@ const MY_DIR = __dirname;
 const DIST_SO_DIR = join(MY_DIR, "../dist/functors");
 
 describe("Instances have equivalent behavior", () => {
-    const samples: Array<[string, string[]]> = [["test/samples/analyses/fcall.sol", ["callsPath"]]];
+    const samples: string[] = ["test/samples/analyses/fcall.sol"];
     // The SouffleSQLiteInstance doesnt work on record types due to
     const instances = [SouffleCSVInstance /*SouffleSQLiteInstance,*/, SouffleCSVToSQLInstance];
 
-    for (const [sample, analyses] of samples) {
+    for (const sample of samples) {
         describe(sample, () => {
             let units: sol.SourceUnit[];
             let datalog: string;
             let reader: sol.ASTReader;
             let version: string;
             let firstInstance: SouffleInstanceI;
+            let analyses: string[];
 
             before(async () => {
                 reader = new sol.ASTReader();
@@ -42,6 +43,7 @@ describe("Instances have equivalent behavior", () => {
                 datalog = buildDatalog(units, infer);
 
                 firstInstance = new instances[0](datalog, DIST_SO_DIR);
+                analyses = [...firstInstance.relations()].map((x) => x.name);
                 await firstInstance.run(analyses);
             });
 
@@ -59,7 +61,6 @@ describe("Instances have equivalent behavior", () => {
                             (fact) => fact.toJSON()
                         );
 
-                        expect(firstInstResult.length > 0).toBeTruthy();
                         expect(firstInstResult).toEqual(otherInstResult);
                     }
                 });


### PR DESCRIPTION
This pr:
- converts csv output to rfc4180
- fixes bugs in parsing string-like things from csv
- fixes performance issues in populating databases by chunking insertions