### PR TITLE
Refactor datalog to separate node fields as separate relations

### DIFF
--- a/scripts/gen_translation_modules.js
+++ b/scripts/gen_translation_modules.js
@@ -115,25 +115,25 @@ const staticPreamble = `
 .decl ContractDefinition_usedErrors(parentId: ContractDefinitionId, childId: ErrorDefinitionId, idx: number)
 .decl ContractDefinition_usedEvents(parentId: ContractDefinitionId, childId: EventDefinitionId, idx: number)
 .decl TupleExpression_components(parentId: TupleExpressionId, childId: ExpressionId, idx: number)
-.decl FunctionDefinition_vModifiers(parentId: FunctionDefinitionId, childId: ModifierInvocationId, idx: number)
-.decl FunctionCall_vArguments(parentId: FunctionCallId, childId: ExpressionId, idx: number)
-.decl TryStatement_vClauses(parentId: TryStatementId, childId: TryCatchClauseId, idx: number)
-.decl VariableDeclarationStatement_vDeclarations(parentId: VariableDeclarationStatementId, childId: VariableDeclarationId, idx: number)
-.decl InheritanceSpecifier_vArguments(parentId: InheritanceSpecifierId, childId: ExpressionId, idx: number)
-.decl ModifierInvocation_vArguments(parentId: ModifierInvocationId, childId: ExpressionId, idx: number)
-.decl ParameterList_vParameters(parentId: ParameterListId, childId: VariableDeclarationId, idx: number)
-.decl Block_vStatements(parentId: BlockId, childId: StatementId, idx: number)
-.decl UncheckedBlock_vStatements(parentId: UncheckedBlockId, childId: StatementId, idx: number)
-.decl UsingForDirective_vFunctionList(parentId: UsingForDirectiveId, childId: IdentifierPathId, operator: symbol, idx: number)
-.decl StructDefinition_vMembers(parentId: StructDefinitionId, childId: VariableDeclarationId, idx: number)
-.decl EnumDefinition_vMembers(parentId: EnumDefinitionId, childId: EnumValueId, idx: number)
+.decl FunctionDefinition_modifiers(parentId: FunctionDefinitionId, childId: ModifierInvocationId, idx: number)
+.decl FunctionCall_arguments(parentId: FunctionCallId, childId: ExpressionId, idx: number)
+.decl TryStatement_clauses(parentId: TryStatementId, childId: TryCatchClauseId, idx: number)
+.decl VariableDeclarationStatement_declarations(parentId: VariableDeclarationStatementId, childId: VariableDeclarationId, idx: number)
+.decl InheritanceSpecifier_arguments(parentId: InheritanceSpecifierId, childId: ExpressionId, idx: number)
+.decl ModifierInvocation_arguments(parentId: ModifierInvocationId, childId: ExpressionId, idx: number)
+.decl ParameterList_parameters(parentId: ParameterListId, childId: VariableDeclarationId, idx: number)
+.decl Block_statements(parentId: BlockId, childId: StatementId, idx: number)
+.decl UncheckedBlock_statements(parentId: UncheckedBlockId, childId: StatementId, idx: number)
+.decl UsingForDirective_functionList(parentId: UsingForDirectiveId, childId: IdentifierPathId, operator: symbol, idx: number)
+.decl StructDefinition_members(parentId: StructDefinitionId, childId: VariableDeclarationId, idx: number)
+.decl EnumDefinition_members(parentId: EnumDefinitionId, childId: EnumValueId, idx: number)
 .decl VariableDeclarationStatement_assignments(parentId: VariableDeclarationStatementId, childId: VariableDeclarationId, idx: number)
-.decl OverrideSpecifier_vOverrides(parentId: OverrideSpecifierId, childId: id, idx: number)
+.decl OverrideSpecifier_overrides(parentId: OverrideSpecifierId, childId: id, idx: number)
 
 .decl FunctionCall_fieldNames(parentId: FunctionCallId, name: symbol, idx: number)
 .decl PragmaDirective_literals(parentId: FunctionCallId, literal: symbol, idx: number)
 .decl SourceUnit_exportedSymbols(parentId: SourceUnitId, name: symbol, id: id)
-.decl FunctionCallOptions_vOptionsMap(parentId: FunctionCallOptionsId, name: symbol, id: id)
+.decl FunctionCallOptions_options(parentId: FunctionCallOptionsId, name: symbol, id: id)
 `;
 
 const skipFields = ["raw", "documentation", "nameLocation", "children", "src"];
@@ -272,8 +272,6 @@ function buildNodeDecls(name, constructor, baseName) {
 
     const res = [`.type ${name}Id <: ${idBaseType}`];
 
-    let dynamicArgs = [];
-
     for (let [paramName, optional, type] of params.slice(2)) {
         if (shouldSkipField(name, paramName)) {
             continue;
@@ -340,40 +338,21 @@ function buildNodeDecls(name, constructor, baseName) {
             datalogT = translateType(type);
         }
 
-        dynamicArgs.push(`${paramName}: ${datalogT}`);
-
         if (optional) {
-            dynamicArgs.push(`has${paramName}: bool`);
+            res.push(`.decl ${name}_${paramName}(id: ${name}Id, val: ${datalogT}, present: bool)`);
+        } else {
+            res.push(`.decl ${name}_${paramName}(id: ${name}Id, val: ${datalogT})`);
         }
     }
 
     if (idBaseType !== "id") {
-        res.push(
-            `${idBaseType.slice(0, -2)}(id) :- ${name}(id${
-                dynamicArgs.length > 0 ? ", " + repeat("_", dynamicArgs.length).join(", ") : ""
-            }).`
-        );
+        res.push(`${idBaseType.slice(0, -2)}(id) :- ${name}(id).`);
     }
 
     // Note that this is a node type
-    res.push(
-        `Node(id) :- ${name}(id${
-            dynamicArgs.length > 0 ? ", " + repeat("_", dynamicArgs.length).join(", ") : ""
-        }).`
-    );
-
-    res.push(
-        `.decl ${name}(id: ${name}Id${dynamicArgs.length > 0 ? ", " + dynamicArgs.join(", ") : ""})`
-    );
-
-    return res;
-}
-
-function repeat(a, n) {
-    const res = [];
-    for (let i = 0; i < n; i++) {
-        res.push(a);
-    }
+    res.push(`Node(id) :- ${name}(id).`);
+    // Add the decl itself
+    res.push(`.decl ${name}(id: ${name}Id)`);
 
     return res;
 }
@@ -643,6 +622,14 @@ const paramRenameMap = new Map([
     ["OverrideSpecifier", new Map([["overrides", "vOverrides"]])]
 ]);
 
+function getCanonicalParamName(className, paramName) {
+    if (paramRenameMap.has(className) && paramRenameMap.get(className).has(paramName)) {
+        return paramRenameMap.get(className).get(paramName);
+    }
+
+    return paramName;
+}
+
 function translateFactArg(name, paramName, type) {
     let ref = `nd.${paramName}`;
 
@@ -715,48 +702,47 @@ function isTsTKnownArray(name, paramName, tsT) {
     return false;
 }
 
-function buildFactInvocation(name, constructor, baseName) {
+function buildFactInvocation(className, constructor, baseName) {
     const rawParams = constructor.getParameters();
     const params = rawParams.map((p) => [p.getName(), p.isOptional(), p.getType().getText()]);
 
     assert(
         params.length >= 2 && params[0][0] === "id" && params[1][0] === "src",
-        `First 2 params are id and src for ${name}`
+        `First 2 params are id and src for ${className}`
     );
 
-    let res = ``;
-
-    // Add src relation
-    res += `res.push(\`src(\${nd.id}, "\${nd.src}").\`);`;
+    // Add anchor and src relations
+    let res = `
+        res.push(\`${className}(\${nd.id}).\`);
+        res.push(\`src(\${nd.id}, "\${nd.src}").\`);
+`;
 
     // Add relations for map arguments
     for (let [paramName, optional] of params.slice(2)) {
         const args = [`\${nd.id}`];
 
-        if (name === "SourceUnit" && paramName === "exportedSymbols") {
+        if (className === "SourceUnit" && paramName === "exportedSymbols") {
             args.push("${'\"' + k + '\"'}", `\${v}`);
-        } else if (name === "FunctionCallOptions" && paramName === `options`) {
+        } else if (className === "FunctionCallOptions" && paramName === `options`) {
             args.push("${'\"' + k + '\"'}", `\${v.id}`);
         } else {
             continue;
         }
 
-        assert(!optional, `Unexpected optional map param ${name}.${paramName}`);
+        assert(!optional, `Unexpected optional map param ${className}.${paramName}`);
 
-        if (paramRenameMap.has(name) && paramRenameMap.get(name).has(paramName)) {
-            paramName = paramRenameMap.get(name).get(paramName);
-        }
+        const canonicalParamName = getCanonicalParamName(className, paramName);
 
         res += `
-    for (let [k, v] of nd.${paramName}.entries()) {
-        res.push(\`${name}_${paramName}(${args.join(", ")}).\`);
+    for (let [k, v] of nd.${canonicalParamName}.entries()) {
+        res.push(\`${className}_${paramName}(${args.join(", ")}).\`);
     }
 `;
     }
 
     // Add relations for array arguments
     for (let [paramName, optional, type] of params.slice(2)) {
-        if (!isTsTKnownArray(name, paramName, type)) {
+        if (!isTsTKnownArray(className, paramName, type)) {
             continue;
         }
 
@@ -764,9 +750,7 @@ function buildFactInvocation(name, constructor, baseName) {
             continue;
         }
 
-        if (paramRenameMap.has(name) && paramRenameMap.get(name).has(paramName)) {
-            paramName = paramRenameMap.get(name).get(paramName);
-        }
+        const canonicalParamName = getCanonicalParamName(className, paramName);
 
         const args = [`\${nd.id}`];
 
@@ -775,14 +759,14 @@ function buildFactInvocation(name, constructor, baseName) {
         } else if (type === `string[]`) {
             args.push(`\${'"' + t + '"'}`);
         } else if (
-            (name === "TupleExpression" && paramName === "components") ||
-            (name === "VariableDeclarationStatement" && paramName === "assignments")
+            (className === "TupleExpression" && canonicalParamName === "components") ||
+            (className === "VariableDeclarationStatement" && canonicalParamName === "assignments")
         ) {
             args.push(`\${t === null ? -1 : t}`);
-        } else if (name === "UsingForDirective" && paramName === "vFunctionList") {
+        } else if (className === "UsingForDirective" && canonicalParamName === "vFunctionList") {
             args.push(`\${t instanceof sol.ASTNode ? t.id : t.definition.id}`);
             args.push(`\${t instanceof sol.ASTNode ? '""' : \`"\${t.operator}"\`}`);
-        } else if (name === "FunctionCall" && paramName === "fieldNames") {
+        } else if (className === "FunctionCall" && canonicalParamName === "fieldNames") {
             args.push(`\${'"' + t + '"'}`);
         } else {
             args.push(`\${t.id}`);
@@ -790,14 +774,23 @@ function buildFactInvocation(name, constructor, baseName) {
 
         args.push(`\${i}`);
 
+        if (
+            (className === "FunctionCall" ||
+                className === "ModifierInvocation" ||
+                className === "InheritanceSpecifier") &&
+            paramName === "args"
+        ) {
+            paramName = "arguments";
+        }
+
         let expr = `
-    for (let i = 0; i < nd.${paramName}.length; i++) {
-        let t = nd.${paramName}[i];
-        res.push(\`${name}_${paramName}(${args.join(", ")}).\`);
+    for (let i = 0; i < nd.${canonicalParamName}.length; i++) {
+        let t = nd.${canonicalParamName}[i];
+        res.push(\`${className}_${paramName}(${args.join(", ")}).\`);
     }
 `;
         if (optional) {
-            expr = `if (nd.${paramName} !== undefined) {
+            expr = `if (nd.${canonicalParamName} !== undefined) {
                 ${expr}
             }`;
         }
@@ -805,25 +798,21 @@ function buildFactInvocation(name, constructor, baseName) {
         res += expr;
     }
 
-    // Build arguments to main relation for the node
-    let dynamicArgs = ["nd.id"];
-
+    // Add relations for normal arguments
     for (let [paramName, optional, type] of params.slice(2)) {
-        if (shouldSkipField(name, paramName)) {
+        if (shouldSkipField(className, paramName)) {
             continue;
         }
 
-        if (name === "ElementaryTypeName" && paramName === "stateMutability") {
+        if (className === "ElementaryTypeName" && paramName === "stateMutability") {
             optional = false;
         }
 
-        if (name === "UserDefinedTypeName" && paramName === "name") {
+        if (className === "UserDefinedTypeName" && paramName === "name") {
             optional = true;
         }
 
-        if (paramRenameMap.has(name) && paramRenameMap.get(name).has(paramName)) {
-            paramName = paramRenameMap.get(name).get(paramName);
-        }
+        const canonicalParamName = getCanonicalParamName(className, paramName);
 
         if (optional) {
             assert(
@@ -833,24 +822,24 @@ function buildFactInvocation(name, constructor, baseName) {
             type = type.slice(0, -12);
         }
 
-        let dynamicArg = translateFactArg(name, paramName, type);
+        let dynamicArg = translateFactArg(className, canonicalParamName, type);
 
         if (optional) {
-            dynamicArg = `nd.${paramName} === undefined ? ${getDefaultValue(
-                name,
-                paramName,
+            dynamicArg = `nd.${canonicalParamName} === undefined ? ${getDefaultValue(
+                className,
+                canonicalParamName,
                 type
             )} : ${dynamicArg}`;
         }
 
-        dynamicArgs.push(dynamicArg);
-
         if (optional) {
-            dynamicArgs.push(`nd.${paramName} !== undefined`);
+            res += `res.push(\`${className}_${paramName}(\${nd.id}, \${translateVal(${dynamicArg})}, \${translateVal(nd.${canonicalParamName} !== undefined)}).\`);`;
+        } else {
+            res += `res.push(\`${className}_${paramName}(\${nd.id}, \${translateVal(${dynamicArg})}).\`);`;
         }
     }
 
-    if (name === "FunctionCall") {
+    if (className === "FunctionCall") {
         res += `if (infer.isFunctionCallExternal(nd)) {
             res.push(\`ExternalCall(\${nd.id}).\`);
         }
@@ -863,8 +852,6 @@ function buildFactInvocation(name, constructor, baseName) {
         }
 `;
     }
-
-    res += `args = translateVals(${dynamicArgs.join(", ")});`;
 
     return res;
 }
@@ -891,10 +878,8 @@ function buildFactBuilderFun(classDescs) {
 
     return `
 export function translateASTNodeInternal(nd: sol.ASTNode, infer: sol.InferType): string[] {
-    let args: string[];
     let res: string[] = [];
     ${body}
-    res.push(\`\${nd.constructor.name}(\${args.join(", ")}).\`);
     return res;
 }
 `;
@@ -958,7 +943,7 @@ async function main() {
     const factBuilderFun = buildFactBuilderFun(classes);
     const translateContents = `
 import * as sol from "solc-typed-ast";
-import { translateVals, sanitizeString } from "../lib/utils";
+import { sanitizeString, translateVal } from "../lib/utils";
 
 ${factBuilderFun}
 `;

--- a/src/lib/analyses/calltree.dl
+++ b/src/lib/analyses/calltree.dl
@@ -1,10 +1,10 @@
 .decl callsDirectly(caller: FunctionDefinitionId, callee: FunctionDefinitionId)
 callsDirectly(caller, callee) :- 
-    FunctionDefinition(caller, _, _, _, _, _, _, _, _, _, _, _, _, _),
-    FunctionDefinition(callee, _, _, _, _, _, _, _, _, _, _, _, _, _),
-    FunctionCall(callId, _, _, exprId),
-    (Identifier(exprId, _, _, callee) ;
-     MemberAccess(exprId, _, _, _, callee)),
+    FunctionDefinition(caller),
+    FunctionDefinition(callee),
+    FunctionCall(callId),
+    FunctionCall_expression(callId, exprId),
+    exprRefersTo(exprId, callee),
     ancestor(caller, callId).
 
 .type CallPath = [ head: FunctionDefinitionId, tail: CallPath ]

--- a/src/lib/analyses/cfg/dominate.dl
+++ b/src/lib/analyses/cfg/dominate.dl
@@ -7,8 +7,8 @@ dominate(pred, succ) :-
 /// If statement A dominates statement B, A dominates all expressions in B
 dominate(pred, succ) :-
     Statement(pred),
-    dominateStmt(pred, B),
     Statement(B),
+    dominateStmt(pred, B),
     ancestor(B, succ),
     Expression(succ).
 
@@ -28,39 +28,54 @@ dominate(pred, succ) :-
 
 /// Assignment
 dominate(pred, succ) :-
-    Assignment(_, _, _, succ, pred).
+    Assignment(aid),
+    Assignment_leftHandSide(aid, succ),
+    Assignment_rightHandSide(aid, pred).
 
 /// BinaryOperation
 dominate(pred, succ) :-
-    BinaryOperation(boId, _, _, pred, succ, _, _).
+    BinaryOperation(boId),
+    BinaryOperation_leftExpression(boId, pred),
+    BinaryOperation_rightExpression(boId, succ).
 
 /// Conditional
 dominate(pred, succ) :-
-    Conditional(_, _, pred, succ, _).
+    Conditional(cId),
+    Conditional_condition(cId, pred),
+    Conditional_trueExpression(cId, succ).
 
 dominate(pred, succ) :-
-    Conditional(_, _, pred, _, succ).
+    Conditional(cId),
+    Conditional_condition(cId, pred),
+    Conditional_falseExpression(cId, succ).
+
 
 /// FunctionCall
 dominate(pred, succ) :-
-    FunctionCall(fcId, _, _, _),
-    FunctionCall_vArguments(fcId, pred, i),
-    FunctionCall_vArguments(fcId, succ, i + 1).
+    FunctionCall(fcId),
+    FunctionCall_arguments(fcId, pred, i),
+    FunctionCall_arguments(fcId, succ, i + 1).
 
 /// IndexAccess
 dominate(pred, succ) :-
-    IndexAccess(_, _, succ, pred, 1).
+    IndexAccess(iaId),
+    IndexAccess_baseExpression(aId, succ),
+    IndexAccess_indexExpression(iaId, pred, 1).
 
 /// IndexRangeAccess
 dominate(pred, succ) :-
-    IndexRangeAccess(_, _, succ, pred, 1, _, _).
+    IndexRangeAccess(iraId), 
+    IndexRangeAccess_baseExpression(iraId, succ),
+    IndexRangeAccess_startExpression(iraId, pred, 1).
 
 dominate(pred, succ) :-
-    IndexRangeAccess(_, _, succ, _, _, pred, 1).
+    IndexRangeAccess(iraId), 
+    IndexRangeAccess_baseExpression(iraId, succ),
+    IndexRangeAccess_endExpression(iraId, pred, 1).
 
 /// TupleExpression
 dominate(pred, succ) :-
-    TupleExpression(tId, _, _),
+    TupleExpression(tId),
     TupleExpression_components(tId, pred, i),
     TupleExpression_components(tId, succ, i + 1).
 

--- a/src/lib/analyses/cfg/dominateStmt.dl
+++ b/src/lib/analyses/cfg/dominateStmt.dl
@@ -2,80 +2,97 @@
 .decl dominateStmt(pred: id, succ: id)
 
 // ForStatement
-// Initialization stmt comes before body
+// Initialization dominates the body when present
 dominateStmt(pred, succ) :-
-    ForStatement(_, succ, pred, 1, _, _, _, _).
+    ForStatement(fsId),
+    ForStatement_initializationExpression(fsId, pred, 1),
+    ForStatement_body(fsId, succ).
+
+// Initialization dominates condition check when both present 
+dominateStmt(pred, succ) :-
+    ForStatement(fsId),
+    ForStatement_initializationExpression(fsId, pred, 1),
+    ForStatement_condition(fsId, succ, 1).
+
+// Initialization dominates loop expr when both present 
+dominateStmt(pred, succ) :-
+    ForStatement(fsId),
+    ForStatement_initializationExpression(fsId, pred, 1),
+    ForStatement_loopExpression(fsId, succ, 1).
 
 // All stmts dominating the for dominate the init statement
 dominateStmt(pred, succ) :-
-    ForStatement(fId, _, succ, 1, _, _, _, _),
+    ForStatement(fsId),
+    ForStatement_initializationExpression(fsId, succ, 1),
     dominateStmt(pred, fId).
 
 // No init statement - all stmts dominating the for dominate the body
 dominateStmt(pred, succ) :-
-    ForStatement(fId, succ, _, 0, _, _, _, _),
+    ForStatement(fsId),
+    ForStatement_initializationExpression(fsId, _, 0),
+    ForStatement_body(fsId, succ),
     dominateStmt(pred, fId).
 
 // TryStatement
 dominateStmt(pred, succ) :-
-    TryStatement(tId, _),
+    TryStatement(tId),
     dominateStmt(pred, tId),
-    TryStatement_vClauses(tId, cId, _),
-    TryCatchClause(cId, _, succ, _, _).
+    TryStatement_clauses(tId, cId, _),
+    TryCatchClause_block(cId, succ).
 
 // BlockStatement
 dominateStmt(pred, succ) :-
     Block(bId),
     dominateStmt(pred, bId),
-    Block_vStatements(bId, succ, 0).
+    Block_statements(bId, succ, 0).
 
 dominateStmt(pred, succ) :-
     Block(bId),
-    Block_vStatements(bId, pred, i),
-    Block_vStatements(bId, succ, i + 1).
+    Block_statements(bId, pred, i),
+    Block_statements(bId, succ, i + 1).
 
 // UncheckedBlockStatement
 dominateStmt(pred, succ) :-
     UncheckedBlock(bId),
     dominateStmt(pred, bId),
-    UncheckedBlock_vStatements(bId, succ, 0).
+    UncheckedBlock_statements(bId, succ, 0).
 
 dominateStmt(pred, succ) :-
     UncheckedBlock(bId),
-    UncheckedBlock_vStatements(bId, pred, i),
-    UncheckedBlock_vStatements(bId, succ, i + 1).
+    UncheckedBlock_statements(bId, pred, i),
+    UncheckedBlock_statements(bId, succ, i + 1).
 
 // WhileStatement
 dominateStmt(pred, succ) :-
-    WhileStatement(wId, _, succ),
+    WhileStatement_body(wId, succ),
     dominateStmt(pred, wId).
 
 // IfStatement
 dominateStmt(pred, succ) :-
-    IfStatement(ifId, _, succ, _, _),
+    IfStatement_trueBody(ifId, succ),
     dominateStmt(pred, ifId).
 
 dominateStmt(pred, succ) :-
-    IfStatement(ifId, _, _, succ, 1),
+    IfStatement_falseBody(ifId, succ, 1),
     dominateStmt(pred, ifId).
 
 // DoWhile statement
 dominateStmt(pred, succ) :-
-    DoWhileStatement(dwId, _, succ),
+    DoWhileStatement_body(dwId, succ),
     dominateStmt(pred, dwId).
 
 // ModifierInvocations
 dominateStmt(pred, succ) :-
-    FunctionDefinition(id, _, _, _, _, _, _, _, _, _, _, _, _, _),
-    FunctionDefinition_vModifiers(id, pred, i),
+    FunctionDefinition(id),
+    FunctionDefinition_modifiers(id, pred, i),
     modifierInvocation_isModifier(pred),
-    FunctionDefinition_vModifiers(id, succ, i + 1),
+    FunctionDefinition_modifiers(id, succ, i + 1),
     modifierInvocation_isModifier(pred).
 
 // ModifierInvocations
 dominateStmt(pred, succ) :-
-    FunctionDefinition(id, _, _, _, _, _, _, _, _, _, _, _, succ, 1),
-    FunctionDefinition_vModifiers(id, pred, i),
+    FunctionDefinition_body(id, succ, 1),
+    FunctionDefinition_modifiers(id, pred, i),
     modifierInvocation_isModifier(pred).
 
 // Transitivity

--- a/src/lib/analyses/common.dl
+++ b/src/lib/analyses/common.dl
@@ -5,40 +5,56 @@ ancestor(x, y) :- parent(x, y).
 ancestor(x, y) :- parent(x, z), ancestor(z, y).
 
 // Helper to get the name of a state var with a given id
-.decl stateVar(name: symbol, id: id)
-stateVar(name, id) :- VariableDeclaration(id, _, _, name, _, 1, _, _, _, _, _, _, _, _, _, _).
+.decl stateVar(id: id, name: symbol)
+stateVar(id, name) :- VariableDeclaration(id), VariableDeclaration_name(id, name), VariableDeclaration_stateVariable(id, 1).
 
 // Helper to get the name of a function with a given id
-.decl function(name: symbol, id: id)
-function(name, id) :- FunctionDefinition(id, _, _, name, _, _, _, _, _, _, _, _, _, _).
+.decl function(id: id, name: symbol)
+function(id, name) :- FunctionDefinition(id), FunctionDefinition_name(id, name).
 
 // Helper to get the name of a function with a given id in a given contract (contractId)
-.decl functionIn(name: symbol, id: FunctionDefinitionId, contractId: id)
-functionIn(name, id, contractId) :- FunctionDefinition(id, contractId, _, name, _, _, _, _, _, _, _, _, _, _).
+.decl functionIn(id: FunctionDefinitionId, name: symbol, contractId: id)
+functionIn(id, name, contractId) :- function(id, name), FunctionDefinition_scope(id, contractId).
 
 // Helper to get the name of a contract with a given id
-.decl contract(name: symbol, id: id)
-contract(name, id) :- ContractDefinition(id, name, _, _, _, _).
+.decl contract(id: id, name: symbol)
+contract(id, name) :- ContractDefinition(id), ContractDefinition_name(id, name).
 
 /// Specifies that a childContractId inherits from baseContractId (or is the same contract)
 .decl inherits(childContractId: ContractDefinitionId, baseContractId: ContractDefinitionId)
-inherits(childContractId, baseContractId) :- ContractDefinition(childContractId, _, _, _, _, _), childContractId = baseContractId.
+inherits(childContractId, baseContractId) :- ContractDefinition(childContractId), childContractId = baseContractId.
 inherits(childContractId, baseContractId) :-
-    ContractDefinition(childContractId, _, _, _, _, _),
-    ContractDefinition(baseContractId, _, _, _, _, _),
+    ContractDefinition(childContractId),
+    ContractDefinition(baseContractId),
     ContractDefinition_linearizedBaseContracts(childContractId, baseContractId, _).
 
 /// Specifies that a method with `methodId` belongs to contract `contractId` or one of its bases.
-.decl method(contractId: ContractDefinitionId, methodId: FunctionDefinitionId)
-method(contractId, methodId) :- inherits(contractId, baseId), functionIn(_ ,methodId, baseId).
+.decl method(methodId: FunctionDefinitionId, contractId: ContractDefinitionId)
+method(methodId, contractId) :- inherits(contractId, baseId), functionIn(methodId, _, baseId).
 
 .decl ModifierInvocation_vReferencedDeclaration(mId: id, rId: id)
 ModifierInvocation_vReferencedDeclaration(mId, rId) :-
-    ModifierInvocation(mId, mNameId, _, _),
-    (Identifier(mNameId, _, _, rId); IdentifierPath(mNameId, _, rId)).
+    ModifierInvocation(mId),
+    ModifierInvocation_modifierName(mId, mNameId),
+    exprRefersTo(mNameId, rId).
 
 .decl modifierInvocation_isModifier(mid: id)
 modifierInvocation_isModifier(mId) :-
-    ModifierInvocation(mId, _, _, _),
+    ModifierInvocation(mId),
     ModifierInvocation_vReferencedDeclaration(mId, rId),
-    ModifierDefinition(rId, _, _, _, _, _, _, _, _).
+    ModifierDefinition(rId).
+
+
+// Specifies that exprId is an Identifier, IdentifierPath or MemberAccess that refers to defId
+.decl exprRefersTo(exprId: id, defId: id)
+exprRefersTo(exprId, defId) :-
+    Identifier(exprId),
+    Identifier_referencedDeclaration(exprId, defId).
+
+exprRefersTo(exprId, defId) :-
+    IdentifierPath(exprId),
+    IdentifierPath_referencedDeclaration(exprId, defId).
+
+exprRefersTo(exprId, defId) :-
+    MemberAccess(exprId),
+    MemberAccess_referencedDeclaration(exprId, defId).

--- a/src/lib/analyses/state_var_modified.dl
+++ b/src/lib/analyses/state_var_modified.dl
@@ -3,19 +3,30 @@
 
 // Simple reference to the variable
 stateVarModifiedInLHS(varId, exprId) :-
-    Identifier(exprId, _, _, varId).
+    Identifier(exprId),
+    Identifier_referencedDeclaration(exprId, varId).
+
 // A member access referring to the variable (e.g. this.x, Foo.x)
 stateVarModifiedInLHS(varId, exprId) :-
-    MemberAccess(exprId, _, _, _, varId).
+    MemberAccess(exprId),
+    MemberAccess_referencedDeclaration(exprId, varId).
+
 // A struct member access x.foo
 stateVarModifiedInLHS(varId, exprId) :-
-    MemberAccess(exprId, _, subExprId, _, _), stateVarModifiedInLHS(varId, subExprId). // A str
+    MemberAccess(exprId),
+    MemberAccess_expression(exprId, subExprId),
+    stateVarModifiedInLHS(varId, subExprId).
+
 // An index into the state var x[a]
 stateVarModifiedInLHS(varId, exprId) :-
-    IndexAccess(exprId, _, baseExprId, _, _), stateVarModifiedInLHS(varId, baseExprId).
+    IndexAccess(exprId),
+    IndexAccess_baseExpression(exprId, baseExprId),
+    stateVarModifiedInLHS(varId, baseExprId).
+ 
 // An tuple expression
 stateVarModifiedInLHS(varId, exprId) :-
-    TupleExpression(exprId, _, 0), 
+    TupleExpression(exprId), 
+    TupleExpression_isInlineArray(exprId, 0),
     TupleExpression_components(exprId, componentId, _),
     componentId >= 0,
     stateVarModifiedInLHS(varId, componentId).
@@ -25,19 +36,20 @@ stateVarModifiedInLHS(varId, exprId) :-
 
 // Simple assignment case
 varModifiedInLHSOfAssignment(varId, assignmentId) :-
-    Assignment(assignmentId, _, _, lhsId, _),
+    Assignment(assignmentId),
+    Assignment_leftHandSide(assignmentId, lhsId),
     stateVarModifiedInLHS(varId, lhsId).
 
 // Compute whether the state var "varContractName.stateVarName" is changed  inside the method "funContractName.funName"
 .decl stateVarAssignedIn(varContractName: symbol, stateVarName: symbol, funContractName: symbol, funName: symbol)
 
 stateVarAssignedIn(varContractName, stateVarName, funContractName, funName) :-
-    contract(varContractName, varContractId),
-    contract(funContractName, funContractId),
-    stateVar(stateVarName, sId),
+    contract(varContractId, varContractName),
+    contract(funContractId, funContractName),
+    stateVar(sId, stateVarName),
     ancestor(varContractId, sId),
-    function(funName, fId),
+    function(fId, funName),
     ancestor(funContractId, fId),
-    Assignment(assignId, _, _, _, _),
+    Assignment(assignId),
     ancestor(fId, assignId),
     varModifiedInLHSOfAssignment(sId, assignId).

--- a/src/lib/detectors/msg_sender_inconsistency.dl
+++ b/src/lib/detectors/msg_sender_inconsistency.dl
@@ -6,14 +6,16 @@
 // Computes all function with id funId that have `msg.sender` expression with id eId
 .decl funHasMsgSenderBuiltin(funId: id, eId: id)
 funHasMsgSenderBuiltin(funId, eId) :-
-    MemberAccess(eId, _, baseId, "sender", _),
-    Identifier(baseId, _, "msg", _),
+    MemberAccess(eId),
+    MemberAccess_expression(eId, baseId),
+    MemberAccess_memberName(eId, "sender"),
+    Identifier_name(baseId, "msg"),
     ancestor(funId, eId).
 
 // Computes all function with id funId that have `_msgSender` expression with id eId
 .decl funHasMsgSenderCall(funId: id, eId: id)
 funHasMsgSenderCall(funId, eId) :-
-    Identifier(eId, _, "_msgSender", _),
+    Identifier_name(eId, "_msgSender"),
     ancestor(funId, eId).
 
 /// MAIN DETECTOR RELATION
@@ -27,10 +29,10 @@ msgSenderInconsistency_Detector(c1, f1, e1, c2, f2, e2) :-
      c1 != c2, inherits(c1, c2);
      c1 != c2, inherits(c2, c1)
     ),
-    method(c1, msgSenderId),
-    function("_msgSender", msgSenderId),
-    functionIn(f1Name, f1, c1),
-    functionIn(f2Name, f2, c2),
+    method(msgSenderId, c1),
+    function(msgSenderId, "_msgSender"),
+    functionIn(f1, f1Name, c1),
+    functionIn(f2, f2Name, c2),
     funHasMsgSenderBuiltin(f1, e1),
     funHasMsgSenderCall(f2, e2),
     f1Name != "_msgSender".

--- a/src/lib/souffle/relation.ts
+++ b/src/lib/souffle/relation.ts
@@ -1,6 +1,6 @@
 import { DatalogType, TypeEnv, mustLookupType } from "./types";
 
-const declRX = /.decl *([a-zA-Z0-9_]*) *\(([^)]*)\)/g;
+const declRX = /\.decl *([a-zA-Z0-9_]*) *\(([^)]*)\)/g;
 
 export class Relation {
     constructor(

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -73,7 +73,7 @@ export function sanitizeString(s: string): string {
         .replaceAll(/[^\x20-\x7E]+/g, ""); // Remove remaining unicode characters
 }
 
-function translateVal(a: any): string {
+export function translateVal(a: any): string {
     if (typeof a === "string") {
         return `"${a}"`;
     }
@@ -93,11 +93,6 @@ function translateVal(a: any): string {
     console.trace();
 
     throw new Error(`Don't know how to translate ${a}`);
-}
-
-export function translateVals(...a: any[]): string[] {
-    // console.error(`translateVals`, a);
-    return a.map(translateVal);
 }
 
 export function searchRecursive(targetPath: string, filter: (entry: string) => boolean): string[] {


### PR DESCRIPTION
This PR changes relations of the form:

```
FunctionDefinition(id, name, ....)
```

to:

```
FunctionDefinition(id).
FuncitonDefinition_name(id, value).
FunctionDefinition_scope(id, value).
```

Please note that we also rename all fields that start with `v` to their version without the `v`. So for example the relation will be `FunctionCall_arguments` instead of `FunctionDefinition_vArguments`.